### PR TITLE
get PC's IP address from QR code; try mDNS if manual IP fails

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -96,10 +96,14 @@
        
 
         <div class="options">
-            <button id="pairManualButton" class="buttonSimple hiddenButton">Connect manually</button>
-            <br><br>
-            <br><br>
-            <br><br>
+            <div id="connectOptionButtons" class="hiddenButton">
+                <button id="pairManualButton" class="buttonSimple">Connect manually</button>
+                <br>
+                <button id="scanIpButton" class="buttonSimple">Connect by QR code</button>
+                <br><br>
+                <br><br>
+                <br><br>
+            </div>
         </div>
         <div id="optionsDialog" class="options">
             <div id="optionButtons" class="hiddenButton">

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -207,16 +207,23 @@ function wsSend(message) {
 }
 
 
+var alternate = 0;
 function wsFind() {
     if (wsIp) {
         wsAddr = 'ws://' + wsIp + ':' + PORT;
         wsName = 'Manually entered';
-        wsStart();
-    } else if (navigator.connection.type === Connection.WIFI) {
-        ZeroConf.watch("_dbb._tcp.local.", wsFound); // does not reconnect if turn off/on wifi
-    } else {
-        checkConnection();
+        if (alternate = !alternate) {
+            wsStart();
+            return;
+        }
     }
+
+    if (navigator.connection.type === Connection.WIFI) {
+        ZeroConf.watch("_dbb._tcp.local.", wsFound); // does not reconnect if turn off/on wifi
+        return;
+    }
+
+    checkConnection();
 }
 
 


### PR DESCRIPTION
Scanning a QR code containing, for example, `{"ip":"10.0.0.1"}` will cause the mobile app to use this address when looking for a DBB app to connect to. If this fails (or a manually entered IP fails), mDNS will also be tried in order to automatically connect.
