### PR TITLE
manual ECDH pairing without wifi

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -57,6 +57,7 @@
         <br>
         
 
+        <button id="pair-manual-button" class="buttonRound hiddenButton">Pair manually</button>
         <button id="details-button" class="buttonRound hiddenButton">Details</button>
         <button id="clear-button" class="buttonRound hiddenButton">Clear</button>
         <button id="pair-begin-button" class="buttonRound hiddenButton">Begin!</button>
@@ -97,17 +98,16 @@
 
         <div class="options">
             <div id="connect-option-buttons" class="hiddenButton">
-                <button id="pair-manual-button" class="buttonSimple">Connect manually</button>
-                <br>
-                <button id="scan-ip-button" class="buttonSimple">Connect by QR code</button>
-                <br><br>
-                <br><br>
-                <br><br>
+                <button id="ip-manual-button" class="buttonSimple">Enter IP address</button>
+                <button id="ip-scan-button" class="buttonSimple">Get IP from QR code</button>
             </div>
+            <br><br>
+            <br><br>
+            <br><br>
         </div>
         <div id="options-dialog" class="options">
             <div id="option-buttons" class="hiddenButton">
-                <button id="pair-option-button" class="buttonSimple">Pair with device</button>
+                <button id="pair-option-button" class="buttonSimple">Pair device</button>
                 <button id="show-scan-button" class="buttonSimple">Scan QR code</button>
                 <!--button id="change-pw-button" class="buttonSimple">Enter password</button-->
                 <button id="forget-pw-button" class="buttonSimple">Forget all</button>


### PR DESCRIPTION
To use, the dbb app needs two modifications: 
- an option to type in the mobile app's shared public key (base58check) by hand, which is then relayed to the dbb as `{"verifypass": {"ecdh":"[pubkey(hex)]"}}`.
- display the dbb's reply in a QR code.
