### PR TITLE
Enable Travis for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+services:
+  - docker
+
+addons:
+  apt:
+    packages:
+      - curl
+      - gnupg2
+
+script:
+- docker build --tag bitbox-2fa-app-ci -f Dockerfile.travis .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: required
 services:
   - docker
 
+os:
+  - linux
+  - osx
+
 addons:
   apt:
     packages:
@@ -10,4 +14,4 @@ addons:
       - gnupg2
 
 script:
-- docker build --tag bitbox-2fa-app-ci -f Dockerfile.travis .
+- ./scripts/travis-ci.sh

--- a/2Fa-gradle.patch
+++ b/2Fa-gradle.patch
@@ -1,0 +1,15 @@
+--- platforms/android/app/build.gradle.old	2018-08-07 11:14:54.432876984 +0000
++++ platforms/android/app/build.gradle	2018-08-07 11:15:27.825299481 +0000
+@@ -33,6 +33,12 @@
+     }
+ }
+ 
++configurations.all {
++   resolutionStrategy {
++       force 'com.android.support:support-v4:27.1.0'
++   }
++}
++
+ // Allow plugins to declare Maven dependencies via build-extras.gradle.
+ allprojects {
+     repositories {

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -1,0 +1,62 @@
+# Copyright 2018 Shift Devices AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+ENV DEBIAN_FRONTEND noninteractive
+WORKDIR /app
+COPY . /app
+
+RUN apt update && apt install -y curl gnupg2 git gcc g++ make coreutils
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt install -y nodejs
+RUN apt install -y npm
+
+RUN echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/unstable.list
+RUN apt update
+RUN apt install -y -t unstable android-sdk android-sdk-platform-23 default-jre
+RUN apt install -y -t unstable openjdk-8-jdk-headless openjdk-8-jre-headless
+RUN apt install -y -t unstable android-platform-tools-base android-sdk 
+RUN apt install -y -t unstable android-sdk-helper
+# Echo the sha1sum of the license text to these files to ensure gradle won't
+# complain about needing to accept a license text. Without this - the build breaks.
+RUN echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "/usr/lib/android-sdk/licenses/android-sdk-preview-license"
+RUN echo -e "\nd56f5187479451eabf01fb78af6dfcb131a6481e" >> "/usr/lib/android-sdk/licenses/android-sdk-license"
+
+ENV JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/"
+ENV ANDROID_HOME="/usr/lib/android-sdk" 
+ENV PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin/:$PATH
+
+RUN mkdir -p /opt/src/2FA-app/
+ADD . /opt/src/2FA-app/
+RUN cd /opt/src/2FA-app/
+
+RUN npm install -g cordova
+RUN npm install -g buffer-reverse
+RUN npm install -g browserify
+
+RUN cordova prepare
+RUN npm install
+RUN npm install bitcore-lib
+
+RUN cordova platform add android
+
+RUN npm list
+RUN browserify www/js/main_new.js -o www/js/app_new.js && \
+   browserify www/js/init.js -o www/js/app_init.js && \
+   browserify www/js/main_old.js -o www/js/app_old.js
+RUN cd platforms/android/app/ && patch < ../../../2Fa-gradle.patch
+
+RUN cordova build android
+RUN cordova build browser
+RUN sha256sum /app/platforms/android/app/build/outputs/apk/debug/app-debug.apk

--- a/scripts/osx-prep.sh
+++ b/scripts/osx-prep.sh
@@ -1,0 +1,23 @@
+# Copyright 2018 Shift Devices AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+brew install nodejs npm
+npm install -g cordova
+npm install -g buffer-reverse
+npm install -g browserify
+cordova prepare
+npm install
+npm install bitcore-lib
+cordova platform add ios
+npm list

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    docker build --tag bitbox-2fa-app-ci -f Dockerfile.travis .;
+fi
+
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    ./scripts/osx-prep.sh;
+    browserify www/js/main_new.js -o www/js/app_new.js && \
+        browserify www/js/init.js -o www/js/app_init.js && \
+        browserify www/js/main_old.js -o www/js/app_old.js
+    cordova build browser
+    cordova build ios
+fi


### PR DESCRIPTION
This branch enables Travis for continuous integration. It uses a Docker container which may also be used locally to test building of the Android package.